### PR TITLE
here is the new MoveToNextLine command and the fix so the new command works even without a window

### DIFF
--- a/plugins/edit_view/lib/edit_view.rb
+++ b/plugins/edit_view/lib/edit_view.rb
@@ -3,6 +3,7 @@ require "edit_view/actions/arrow_keys"
 require "edit_view/actions/deletion"
 require "edit_view/actions/esc"
 require "edit_view/actions/tab"
+require "edit_view/actions/cmd_enter"
 require "edit_view/command"
 require "edit_view/document"
 require "edit_view/document/command"
@@ -173,6 +174,10 @@ module Redcar
     def self.esc_handlers
       [Actions::EscapeHandler]
     end
+    
+    def self.cmd_enter_handlers
+      [Actions::CmdEnterHandler]
+    end
 
     def self.all_tab_handlers
       all_handlers(:tab)
@@ -196,6 +201,10 @@ module Redcar
 
     def self.all_backspace_handlers
       all_handlers(:backspace)
+    end
+    
+    def self.all_cmd_enter_handlers
+      all_handlers(:cmd_enter)
     end
 
     def handle_key(handlers, modifiers)
@@ -232,6 +241,10 @@ module Redcar
 
     def backspace_pressed(modifiers)
       handle_key(EditView.all_backspace_handlers, modifiers)
+    end
+    
+    def cmd_enter_pressed(modifiers)
+      handle_key(EditView.all_cmd_enter_handlers, modifiers)
     end
 
     # Called by the GUI whenever an EditView is focussed or

--- a/plugins/edit_view/lib/edit_view/actions/cmd_enter.rb
+++ b/plugins/edit_view/lib/edit_view/actions/cmd_enter.rb
@@ -1,0 +1,11 @@
+module Redcar
+  class EditView
+    module Actions
+      class CmdEnterHandler
+        def self.handle(edit_view, modifiers)
+          Redcar::Top::MoveNextLineCommand.new.run
+        end
+      end
+    end
+  end
+end

--- a/plugins/edit_view_swt/lib/edit_view_swt.rb
+++ b/plugins/edit_view_swt/lib/edit_view_swt.rb
@@ -322,6 +322,8 @@ module Redcar
       end
 
       def verify_key(key_event)
+        #uncomment this line for key debugging
+        #puts "got keyevent: #{key_event.character} #{key_event.stateMask}"
         if @edit_view_swt.model.document.block_selection_mode?
           @edit_view_swt.begin_compound
         end
@@ -337,6 +339,8 @@ module Redcar
           key_event.doit = !@edit_view_swt.model.delete_pressed(ApplicationSWT::Menu::BindingTranslator.modifiers(key_event))
         elsif key_event.character == Swt::SWT::BS
           key_event.doit = !@edit_view_swt.model.backspace_pressed(ApplicationSWT::Menu::BindingTranslator.modifiers(key_event))
+        elsif key_event.character == 13 and (key_event.stateMask == Swt::SWT::COMMAND or key_event.stateMask == Swt::SWT::CTRL)
+          key_event.doit = !@edit_view_swt.model.cmd_enter_pressed(ApplicationSWT::Menu::BindingTranslator.modifiers(key_event))
         end
       end
     end

--- a/plugins/redcar/redcar.rb
+++ b/plugins/redcar/redcar.rb
@@ -82,7 +82,12 @@ module Redcar
     class NewCommand < Command
 
       def execute
-        tab = win.new_tab(Redcar::EditTab)
+        unless win.nil?
+          tab = win.new_tab(Redcar::EditTab)
+        else
+          window = Redcar.app.new_window
+          tab = window.new_tab(Redcar::EditTab)          
+        end
         tab.title = "untitled"
         tab.focus
         tab
@@ -407,8 +412,22 @@ Redcar.environment: #{Redcar.environment}
       end
     end
 
-    class MoveBottomCommand < DocumentCommand
+    class MoveNextLineCommand < DocumentCommand
+      def execute
+        doc = tab.edit_view.document
+        line_ix = doc.line_at_offset(doc.cursor_offset)
+        if line_ix == doc.line_count - 1
+          doc.cursor_offset = doc.length
+        else
+          doc.cursor_offset = doc.offset_at_line(line_ix + 1) - doc.delim.length
+        end
+        doc.ensure_visible(doc.cursor_offset)
+        doc.insert(doc.cursor_offset, "\n")
+        
+      end
+    end
 
+    class MoveBottomCommand < DocumentCommand
       def execute
         doc.cursor_offset = doc.length
         doc.ensure_visible(doc.length)
@@ -747,6 +766,8 @@ Redcar.environment: #{Redcar.environment}
         link "Cmd+W",       CloseTabCommand
         link "Cmd+Shift+W", CloseWindowCommand
         link "Cmd+Q",       QuitCommand
+        
+        #link "Cmd+Return",   MoveNextLineCommand
 
         link "Cmd+Shift+E", EditView::InfoSpeedbarCommand
         link "Cmd+Z",       UndoCommand
@@ -820,6 +841,8 @@ Redcar.environment: #{Redcar.environment}
         link "Ctrl+W",       CloseTabCommand
         link "Ctrl+Shift+W", CloseWindowCommand
         link "Ctrl+Q",       QuitCommand
+        
+        link "Ctrl+Enter",   MoveNextLineCommand
 
         link "Ctrl+Shift+E", EditView::InfoSpeedbarCommand
         link "Ctrl+Z",       UndoCommand


### PR DESCRIPTION
here is the new MoveToNextLine command and the fix so the new command works even without a window

I haven't tested it on linux so the keybinding ctrl+enter may not work.

let me know if you need anything else changed.
