### PR TITLE
Handle iTerm* as a terminal app on OS X.

### DIFF
--- a/plugins/project/lib/project/commands.rb
+++ b/plugins/project/lib/project/commands.rb
@@ -245,19 +245,22 @@ module Redcar
 
     class RevealInProjectCommand < ProjectCommand
       def execute
-        tab = Redcar.app.focussed_window.focussed_notebook_tab
-        return unless tab.is_a?(EditTab)
+        if project and project.window.trees_visible?
+          tab = Redcar.app.focussed_window.focussed_notebook_tab
+          return unless tab.is_a?(EditTab) && tab.edit_view.document.mirror
 
-        path = tab.edit_view.document.mirror.path
-        tree = project.tree
-        current = tree.tree_mirror.top
-        while current.any?
-          ancestor_node = current.detect {|node| path =~ /^#{node.path}($|\/)/}
-          tree.expand(ancestor_node)
-          current = ancestor_node.children
+          path = tab.edit_view.document.mirror.path
+          tree = project.tree
+          current = tree.tree_mirror.top
+          while current.any?
+            ancestor_node = current.detect {|node| path =~ /^#{node.path}($|\/)/}
+            return unless ancestor_node
+            tree.expand(ancestor_node)
+            current = ancestor_node.children
+          end
+          tree.select(ancestor_node)
+          project.window.treebook.focus_tree(project.tree)
         end
-        tree.select(ancestor_node)
-        project.window.treebook.focus_tree(project.tree)
       end
     end
 


### PR DESCRIPTION
I'm using the beta labeled "iTerm 2", hence the regexp to match the app name.
