### PR TITLE
Fix tool tip being misplaced (at least on windows7)

### DIFF
--- a/plugins/application_swt/lib/application_swt/dialog_adapter.rb
+++ b/plugins/application_swt/lib/application_swt/dialog_adapter.rb
@@ -89,8 +89,8 @@ module Redcar
       def tool_tip(message, location)
         tool_tip = Swt::Widgets::ToolTip.new(parent_shell, Swt::SWT::ICON_INFORMATION)
         tool_tip.set_message(message)
-        tool_tip.set_visible(true)
         tool_tip.set_location(*get_coordinates(location))
+        tool_tip.set_visible(true)
       end
       
       def popup_menu(menu, location)


### PR DESCRIPTION
The code was making the tooltip visible before setting its location making it always being displayed at the default location of the mouse pointer.
Simple fix is just moving the set_location before set_visible.
Affected windows, don't know if behavior different on other platforms but should be safe change since this is the logical order to do it in.
