### PR TITLE
Exclude Gemfile.lock file and .bundle directory from git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ plugins/repl/vendor/org-enclojure-repl-server.jar
 vendor/swtbot
 .server.yaml
 .yardoc
+
+Gemfile.lock
+.bundle


### PR DESCRIPTION
It seems like Gemfile.lock and .bundle aren't being checked in so this ensures that they definitely don't
