### PR TITLE
Closes #331. Pair highlighter doesn't work if it's on a pair that is the first or last digit of the document

### DIFF
--- a/plugins/pair_highlighter/lib/pair_highlighter/document_controller.rb
+++ b/plugins/pair_highlighter/lib/pair_highlighter/document_controller.rb
@@ -74,15 +74,12 @@ module Redcar
         end
       end
       
-      def find_pair(step, offset, search_char, current_char)
-        if offset == 0
-          return nil
-        end
+      def find_pair(step, offset, search_char, current_char)        
         state = 1;
         quotes = false
         doublequotes = false
         
-        while offset > 0 and offset < document.length - 1
+        while offset >= 0 and offset < document.length
           offset = offset + step;
           @newchar = styledText.getTextRange(offset, 1)
           if @newchar == search_char and !quotes and !doublequotes


### PR DESCRIPTION
```
[1,2,3].each { |f|
  puts f
}
```

If there's no white-space before "[" or after the "}" then it won't highlight it correctly.
