### PR TITLE
Specify cucumber requirement in Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ vendor/swtbot
 .server.yaml
 .yardoc
 
-Gemfile.lock
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 gem 'rake'
 gem 'rspec', "<2.0.0"
-gem 'cucumber'
+gem 'cucumber', "~>0.9"
 gem 'ci_reporter', :group => "ci"
 gem 'rcov', "=0.9.9", :group => "ci"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    builder (2.1.2)
+    ci_reporter (1.6.3)
+      builder (>= 2.1.2)
+    cucumber (0.9.4)
+      builder (~> 2.1.2)
+      diff-lcs (~> 1.1.2)
+      gherkin (~> 2.2.9)
+      json (~> 1.4.6)
+      term-ansicolor (~> 1.0.5)
+    diff-lcs (1.1.2)
+    gherkin (2.2.9-java)
+      json (~> 1.4.6)
+      term-ansicolor (~> 1.0.5)
+    json (1.4.6-java)
+    rake (0.8.7)
+    rcov (0.9.9-java)
+    rspec (1.3.1)
+    term-ansicolor (1.0.5)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  ci_reporter
+  cucumber (~> 0.9)
+  rake
+  rcov (= 0.9.9)
+  rspec (< 2.0.0)


### PR DESCRIPTION
Since we require cucumber 0.9 series, it's better to specify it in Gemfile. Without this, `bundle install` might not work out of the box.
