### PR TITLE
Mostly TextMate-compat

### DIFF
--- a/plugins/line_tools/features/trim_line.feature
+++ b/plugins/line_tools/features/trim_line.feature
@@ -22,3 +22,52 @@ Scenario: Trimming a line with unicode
   And I move the cursor to 5
   And I trim the line
   Then the contents should be "foo\nb\nbaz"
+
+Scenario: Trimming a line with Windows line endings
+  When I open a new edit tab
+  And I replace the contents with "foo\r\nbść\r\nbaz"
+  And I move the cursor to 6
+  And I trim the line
+  Then the contents should be "foo\r\nb\r\nbaz"
+
+Scenario: Trimming empty line removes newline character
+  When I open a new edit tab
+  And I replace the contents with "foo\n\nbaz"
+  And I move the cursor to 4
+  And I trim the line
+  Then the contents should be "foo\nbaz"
+
+Scenario: Trimming empty line removes newline character (Windows)
+  When I open a new edit tab
+  And I replace the contents with "foo\r\n\r\nbaz"
+  And I move the cursor to 5
+  And I trim the line
+  Then the contents should be "foo\r\nbaz"
+
+Scenario: Trimming when at end of line removes newline character
+  When I open a new edit tab
+  And I replace the contents with "foo\nbść\nbaz"
+  And I move the cursor to 7
+  And I trim the line
+  Then the contents should be "foo\nbśćbaz"
+
+Scenario: Trimming when at end of file and newline absent it does nothing
+  When I open a new edit tab
+  And I replace the contents with "foo\nbść\nbaz"
+  And I move the cursor to 11
+  And I trim the line
+  Then the contents should be "foo\nbść\nbaz"
+
+Scenario: Trimming when just before last newline character it removes it
+  When I open a new edit tab
+  And I replace the contents with "foo\nbść\nbaz\n"
+  And I move the cursor to 11
+  And I trim the line
+  Then the contents should be "foo\nbść\nbaz"
+
+Scenario: Trimming when at end of file and newline present it does nothing
+  When I open a new edit tab
+  And I replace the contents with "foo\nbść\nbaz\n"
+  And I move the cursor to 12
+  And I trim the line
+  Then the contents should be "foo\nbść\nbaz\n"

--- a/plugins/line_tools/lib/line_tools.rb
+++ b/plugins/line_tools/lib/line_tools.rb
@@ -92,7 +92,11 @@ module Redcar
           text = doc.get_slice(offset, doc.offset_at_line_end(line_ix))
         end
         doc.controllers(Redcar::AutoIndenter::DocumentController).first.disable do
-          doc.replace(offset, text.split(//).length, "\n")
+          if text == doc.line_delimiter or text == ""
+            doc.replace(offset, text.split(//).length, "")
+          else
+            doc.replace(offset, text.split(//).length, doc.line_delimiter)
+          end
         end
         #doc.cursor_offset = doc.cursor_offset - 1
       end

--- a/plugins/project/features/find_file.feature
+++ b/plugins/project/features/find_file.feature
@@ -22,6 +22,13 @@ Feature: Find file
     Then the filter dialog should have 1 entry
     And I should see "foo_spec.rb (myproject/spec)" at 0 the filter dialog
 
+  Scenario: One matching file - spaces ignored
+    When I run the command Redcar::Project::FindFileCommand
+    And I set the filter to "foo spec"
+    And I wait "0.4" seconds
+    Then the filter dialog should have 1 entry
+    And I should see "foo_spec.rb (myproject/spec)" at 0 the filter dialog
+
   Scenario: Two matching files
     When I run the command Redcar::Project::FindFileCommand
     And I set the filter to "foo"
@@ -31,7 +38,16 @@ Feature: Find file
     And I should see "foo_lib.rb (myproject/lib_symlink)" at 1 the filter dialog
     And I should see "foo_spec.rb (myproject/spec)" at 2 the filter dialog
     
-  Scenario: One matching file with arbitrary letters
+  Scenario: Two matching files - spaces ignored
+    When I run the command Redcar::Project::FindFileCommand
+    And I set the filter to "foo rb"
+    And I wait "0.4" seconds
+    Then the filter dialog should have 3 entries
+    And I should see "foo_lib.rb (myproject/lib)" at 0 the filter dialog
+    And I should see "foo_lib.rb (myproject/lib_symlink)" at 1 the filter dialog
+    And I should see "foo_spec.rb (myproject/spec)" at 2 the filter dialog
+
+Scenario: One matching file with arbitrary letters
     When I run the command Redcar::Project::FindFileCommand
     And I set the filter to "fsc"
     And I wait "0.4" seconds

--- a/plugins/project/lib/project/find_file_dialog.rb
+++ b/plugins/project/lib/project/find_file_dialog.rb
@@ -98,14 +98,14 @@ module Redcar
       end
       
       def find_files_from_list(text, file_list)
-        re = make_regex(text)
+        re = make_regex(text.gsub(/\s/, ""))
         file_list.select { |fn| 
           fn.split('/').last =~ re
         }.compact
       end
       
       def find_files(text, directories)
-        filter_and_rank_by(project.all_files.sort, text) do |fn|
+        filter_and_rank_by(project.all_files.sort, text.gsub(/\s/, "")) do |fn|
           fn.split("/").last
         end
       end

--- a/plugins/redcar/redcar.rb
+++ b/plugins/redcar/redcar.rb
@@ -960,7 +960,9 @@ Redcar.environment: #{Redcar.environment}
 
         link "Ctrl+Home",    MoveTopCommand
         link "Home",         MoveHomeCommand
+        link "Ctrl+A",       MoveHomeCommand
         link "End",          MoveEndCommand
+        link "Ctrl+E",       MoveEndCommand
         link "Ctrl+End",     MoveBottomCommand
 
         link "Ctrl+[",       DecreaseIndentCommand
@@ -971,7 +973,7 @@ Redcar.environment: #{Redcar.environment}
         link "Ctrl+H",       DocumentSearch::SearchAndReplaceCommand
         link "F3",           DocumentSearch::RepeatPreviousSearchForwardCommand
         link "Ctrl+Shift+F", Redcar::FindInProject::OpenSearch
-        link "Ctrl+A",       SelectAllCommand
+        link "Ctrl+Shift+A", SelectAllCommand
         link "Ctrl+Alt+W",   SelectWordCommand
         link "Ctrl+B",       ToggleBlockSelectionCommand
         link "Ctrl+Space",       AutoCompleter::AutoCompleteCommand


### PR DESCRIPTION
Working off my wishlist at http://t-a-w.blogspot.com/2010/12/my-christmas-wishlist-redcar-and.html

Changes are:
- TextMate/Emacs-compatible Ctrl-A/Ctrl-E on all systems (and select all moved to Ctrl-Shift-A)
- Ctrl-T to ignore spaces like in TextMate
- Ctrl-K fixed support for \r\n
- Ctrl-K handles edge cases (end of line, end of file) like TextMate - it will remove \n if you press Ctrl-K just before \n; it won't append unnecessary \n at end of file etc.
- Relevant tests.

All these changes have low impact.
