### PR TITLE
English Color Names

### DIFF
--- a/plugins/application_swt/spec/application_swt/gradient_spec.rb
+++ b/plugins/application_swt/spec/application_swt/gradient_spec.rb
@@ -119,4 +119,24 @@ describe Redcar::ApplicationSWT::Gradient do
   
   end
   
+  context "when constructed with a color name" do
+    
+    subject { Redcar::ApplicationSWT::Gradient.new( "black" ) }
+    
+    it "should return the SWT system color corresponding to that name" do
+      subject.swt_colors[0].should == Redcar::ApplicationSWT.display.get_system_color(Swt::SWT::COLOR_BLACK)
+    end
+    
+  end
+  
+  context "when constructed with the color 'none'" do
+    
+    subject { Redcar::ApplicationSWT::Gradient.new( "none" ) }
+    
+    it "should return the SWT system color corresponding to that name" do
+      subject.swt_colors[0].should == Redcar::ApplicationSWT.display.get_system_color(Swt::SWT::NONE)
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
I added English color names backed by SWT constants to the Gradient class.

Now you can set the background color to "widget_background" if you want Redcar to look like it did before my previous changes.
