### PR TITLE
Base storage

### DIFF
--- a/plugins/core/lib/core/plugin/storage.rb
+++ b/plugins/core/lib/core/plugin/storage.rb
@@ -86,8 +86,8 @@ module Redcar
     end
     
     class Storage < Plugin::BaseStorage
-      class << self
-        attr_writer :storage_dir
+      def self.storage_dir=(value)
+        @user_dir = value
       end
     
       def self.storage_dir

--- a/plugins/core/spec/core/base_storage_spec.rb
+++ b/plugins/core/spec/core/base_storage_spec.rb
@@ -1,0 +1,81 @@
+
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe Redcar::Plugin::BaseStorage do
+  
+  before :each do
+    @tmp_dir = File.join(File.dirname(__FILE__), "tmp")
+    FileUtils.mkdir_p(@tmp_dir)
+  end
+  
+  after :each do
+    FileUtils.rm_rf(@tmp_dir)
+  end
+  
+  def get_new_storage
+    Redcar::Plugin::BaseStorage.new(@tmp_dir, 'test_storage_saved')
+  end
+  
+  it "acts like a hash" do
+    storage = get_new_storage
+    storage[:some_key] = "some value"
+    storage[:some_key].should == "some value"
+    storage[:some_key] = "some other value"
+    storage[:some_key].should == "some other value"
+  end
+
+  it "saves to disk" do
+    storage = get_new_storage
+    storage[:some_key] = "some value"
+    storage = get_new_storage
+    storage[:some_key].should == "some value"
+    
+    FileUtils.rm_rf(storage.send(:path))
+    storage = get_new_storage
+    storage[:some_key].should be_nil
+  end
+  
+  it "has a set default method" do
+    storage = get_new_storage
+    storage.set_default('a', 'b')    
+    storage['a'].should == 'b'
+    storage = get_new_storage
+    storage['a'].should == 'b'
+    storage['a'] = 'c'
+    storage['a'].should == 'c'
+    storage = get_new_storage
+    storage['a'].should == 'c'
+    storage['b'] = false
+    storage.set_default('b', true)
+    storage['b'].should == false
+  end
+  
+  it "should raise an error when the storage file is invalid/corrupt" do
+    storage = get_new_storage
+    FileUtils.touch(storage.send(:path))
+    lambda { storage.rollback }.should raise_error(RuntimeError)
+  end
+  
+  it "should reload when the storage file itself has been elsewise modified" do
+    storage = get_new_storage
+    storage['a'] = 'b'
+    storage['a'].should == 'b'
+    storage['a'].should == 'b'
+    sleep 1 # windows doesn't have finer granularity than this
+    File.open(storage.send(:path), 'w') do |f|
+      f.write "---
+                a: new"
+    end    
+    storage['a'].should == 'new'
+    storage['a'].should == 'new'
+    storage = get_new_storage
+    storage['a'].should == 'new'    
+  end
+  
+  it "should allow per-instance storage directory" do
+    storage  = Redcar::Plugin::BaseStorage.new(@tmp_dir, 'test_storage_saved')
+    storage2 = Redcar::Plugin::BaseStorage.new(File.join(@tmp_dir, "sub"), 'test_storage_saved')
+    storage.send(:path).should_not == storage2.send(:path)
+  end
+  
+end

--- a/plugins/core/spec/core/storage_spec.rb
+++ b/plugins/core/spec/core/storage_spec.rb
@@ -3,75 +3,25 @@ require File.join(File.dirname(__FILE__), "..", "spec_helper")
 
 describe Redcar::Plugin::Storage do
   
-  before do
-    remove_test_files
+  it "should be based on Redcar::Plugin::BaseStorage" do
+    Redcar::Plugin::Storage.ancestors.should include(Redcar::Plugin::BaseStorage)
   end
   
-  after do
-    remove_test_files
+  it "should have a default storage path" do
+    Redcar::Plugin::Storage.storage_dir.should == File.join(Redcar.user_dir, "storage")
   end
   
-  def remove_test_files
-    FileUtils.rm_rf(Redcar::Plugin::Storage.new('test_storage_saved').send(:path))
-    FileUtils.rm_rf(Redcar::Plugin::Storage.new('test_storage_saved2').send(:path))
+  it "should have a configurable storage path" do
+    old_storage_dir = Redcar::Plugin::Storage.storage_dir
+    Redcar::Plugin::Storage.storage_dir = File.dirname(__FILE__)
+    Redcar::Plugin::Storage.storage_dir.should == File.dirname(__FILE__)
+    Redcar::Plugin::Storage.storage_dir = old_storage_dir
   end
   
-  it "acts like a hash" do
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage[:some_key] = "some value"
-    storage[:some_key].should == "some value"
-    storage[:some_key] = "some other value"
-    storage[:some_key].should == "some other value"
+  it "should store files inside the directory specified by storage path" do
+    Redcar::Plugin::Storage.storage_dir = File.dirname(__FILE__)
+    storage = Redcar::Plugin::Storage.new('test_storage')
+    storage.send(:path).should == File.join(File.dirname(__FILE__), 'test_storage.yaml')
   end
-
-  it "saves to disk" do
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage[:some_key] = "some value"
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage[:some_key].should == "some value"
     
-    FileUtils.rm_rf(storage.send(:path))
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage[:some_key].should be_nil
-  end
-  
-  it "has a set default method" do
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage.set_default('a', 'b')    
-    storage['a'].should == 'b'
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage['a'].should == 'b'
-    storage['a'] = 'c'
-    storage['a'].should == 'c'
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage['a'].should == 'c'
-    storage['b'] = false
-    storage.set_default('b', true)
-    storage['b'].should == false
-  end
-  
-  it "should have the default work when that's the first method called" do
-    storage = Redcar::Plugin::Storage.new('test_storage_saved2')
-    FileUtils.touch(storage.send(:path))
-    lambda { storage.rollback }.should raise_error(RuntimeError)
-    FileUtils.rm(storage.send(:path))
-  end
-  
-  it "should reload when the storage file itself has been elsewise modified" do
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage['a'] = 'b'
-    storage['a'].should == 'b'
-    storage['a'].should == 'b'
-    sleep 1 # windows doesn't have finer granularity than this
-    File.open(storage.send(:path), 'w') do |f|
-      f.write "---
-                a: new"
-    end    
-    storage['a'].should == 'new'
-    storage['a'].should == 'new'
-    storage = Redcar::Plugin::Storage.new('test_storage_saved')
-    storage['a'].should == 'new'    
-  end
-  
-  
 end


### PR DESCRIPTION
In working on project_loader I came across the fact that Plugin::Storage was very tightly coupled to Redcar.user_dir.  This made using the Storage class for per-project storage (<project-dir>/.redcar) impossible.  To reduce the amount of overrides in attempting to subclass Storage, I felt it made more sense to make Storage a subclass of a new class (BaseStorage) that made storage_dir an instance variable.  Storage simply sets the instance value when the new instance is created.

Finally, in writing specs for BaseStorage and refactoring the Storage specs I came across an un-tested bug in Storage.storage_dir=.  It was setting @storage_dir whereas Storage.storage_dir reads from @user_dir.  I fixed the bug and added a new spec to cover this.
