### PR TITLE
Plugin tab events

### DIFF
--- a/plugins/application/lib/application.rb
+++ b/plugins/application/lib/application.rb
@@ -243,7 +243,11 @@ module Redcar
     # @param [Symbol] method_name
     def call_on_plugins(method_name, *args)
       Redcar.plugin_manager.objects_implementing(method_name).each do |object|
-        yield object.send(method_name, *args)
+        if block_given?
+          yield object.send(method_name, *args)
+	else
+	  object.send(method_name, *args)
+	end
       end
       nil
     end

--- a/plugins/application/lib/application/notebook.rb
+++ b/plugins/application/lib/application/notebook.rb
@@ -34,6 +34,7 @@ module Redcar
       notify_listeners(:tab_added, tab) do
         @tabs << tab
       end
+      Redcar.app.call_on_plugins(:tab_added, tab)
       tab
     end
     
@@ -142,6 +143,7 @@ module Redcar
         select_tab!(tab)
       end
       @tab_handlers[tab] << tab.add_listener(:close) do
+        Redcar.app.call_on_plugins(:tab_closed, tab)
         remove_tab!(tab)
         notify_listeners(:tab_closed)
       end


### PR DESCRIPTION
As discussed on the mailing list I implemented two new plugin hooks, tab_added and tab_closed, that both provide the tab in question as the only argument to the hook.
