### PR TITLE
Add the project to window_projects earlier so it can be found during tab 

### DIFF
--- a/plugins/project/lib/project.rb
+++ b/plugins/project/lib/project.rb
@@ -79,12 +79,13 @@ module Redcar
       attach_listeners
       window.title = File.basename(@tree.tree_mirror.path)
       Manager.open_project_sensitivity.recompute
+      Project.window_projects[window] = self
       Redcar.plugin_manager.objects_implementing(:project_loaded).each do |i|
         i.project_loaded(self)
       end
       Recent.store_path(path)
       Manager.storage['last_open_dir'] = path
-      Project.window_projects[window] = self
+      self
     end
 
     def lock


### PR DESCRIPTION
I have come across a scenario in my cursor_saver plugin that requires finding the project in window_projects (via Project::Manager) during the newly added tab_added plugin callback.  Unfortunately, without the change in this pull request, the project cannot be found during the tab event because it's not yet in window_projects.  This change puts the project itself in window_projects before calling project_loaded on plugins.  This makes sense to me regardless of whether or not there are alternative solutions for my plugin scenario.
