### PR TITLE
expose FileMirror timestamp + bugfix

### DIFF
--- a/plugins/project/lib/project/file_mirror.rb
+++ b/plugins/project/lib/project/file_mirror.rb
@@ -10,7 +10,7 @@ module Redcar
     class FileMirror
       include Redcar::Document::Mirror
       
-      attr_reader :path, :adapter
+      attr_reader :path, :adapter, :timestamp
       
       # @param [String] a path to a file
       def initialize(path, adapter=Adapters::Local.new)
@@ -49,7 +49,7 @@ module Redcar
       
       def changed_since?(time)
         begin
-          !@timestamp or (!time and changed?) or (time and time < File.mtime(@path))
+          !@timestamp or (!time and changed?) or (time and time < @adapter.mtime(@path))
         rescue Errno::ENOENT
           false
         end
@@ -61,7 +61,7 @@ module Redcar
       # @return [unspecified]
       def commit(contents)
         save_contents(contents)
-        @time = Time.now
+        @timestamp = @adapter.mtime(@path)
       end
       
       # The filename.

--- a/plugins/project/spec/project/file_mirror_spec.rb
+++ b/plugins/project/spec/project/file_mirror_spec.rb
@@ -70,6 +70,16 @@ class Redcar::Project
           it "tells you it has changed" do
             @mirror.changed?.should be_true
           end
+          
+          describe "and since committed" do
+            before do
+              @mirror.commit("the queen")
+            end
+            
+            it "tells you it has not changed" do
+              @mirror.changed?.should be_false
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Exposes `@timestamp` from `FileMirror` as `FileMirror#timestamp` and fix a bug that prevents it from being updated when the mirror is committed.
