### PR TITLE
Add ensure_cursor_visible and scroll_to_offset_at_middle.

### DIFF
--- a/plugins/edit_view/lib/edit_view/document.rb
+++ b/plugins/edit_view/lib/edit_view/document.rb
@@ -663,6 +663,19 @@ module Redcar
     def scroll_to_line_at_top(line_ix)
       @edit_view.controller.scroll_to_line(line_ix)
     end
+    
+    # Tries to scroll so the given line is in the middle of the viewport.  If the line
+    # is above (smaller index) than the midline, defers to scroll_to_line_at_top(0).
+    #
+    # @param [Integer] line_ix  a zero-based line index
+    def scroll_to_line_at_middle(line_ix)
+      midline = num_lines_visible / 2
+      if line_ix > midline
+        scroll_to_line_at_top(line_ix - midline)
+      else
+        scroll_to_line_at_top(0)
+      end
+    end
 
     # The line_ix of the line at the top of the viewport.
     #
@@ -689,9 +702,21 @@ module Redcar
     def ensure_visible(offset)
       @edit_view.controller.ensure_visible(offset)
     end
+    
+    # Ensures the cursor is visible as near the center of the viewport as possible.  Scrolls
+    # vertically until the cursor is near the center.  Scrolls horizontally only enough to make
+    # the cursor visible.
+    def ensure_cursor_visible
+      scroll_to_line_at_middle(cursor_line)
+      ensure_visible(cursor_offset) unless visible_horizontal_index_range.include?(cursor_line_offset)
+    end
 
     def num_lines_visible
       biggest_visible_line - smallest_visible_line
+    end
+    
+    def visible_horizontal_index_range
+      smallest_visible_horizontal_index .. largest_visible_horizontal_index
     end
 
     # The scope hierarchy at this point


### PR DESCRIPTION
As discussed on the mailing list, the added methods support the ability to ensure the cursor is visible as close to the center of the view as possible.
