### PR TITLE
explicit GC at end of app to help with clean exit

### DIFF
--- a/bin/redcar
+++ b/bin/redcar
@@ -27,3 +27,9 @@ Redcar.spin_up
 Redcar.load_threaded
 Redcar.show_splash
 Redcar.pump
+
+# enforce a GC run to help with a clean exit.
+# When mixing SWT and Swing this is necessary.
+mem_bean = java.lang.management.ManagementFactory.getMemoryMXBean()
+mem_bean.gc
+


### PR DESCRIPTION
Hi,

I have a plugin that fires up some swing windows and I noticed that redcar did not close properly on exit after these windows had been opened. Making sure I did not hold on to any references etc I eventually stumbeled upon running the jvm GC explicitly at the end of the app and by that got a clean exit.

Looks like a pretty harmless change - an extra GC can't matter in the general case.

Mind including this?

Thanks
