### PR TITLE
Disabled plugins

### DIFF
--- a/plugins/edit_view/lib/edit_view.rb
+++ b/plugins/edit_view/lib/edit_view.rb
@@ -103,13 +103,13 @@ module Redcar
             sub_menu "Tabs" do
               item "Soft Tabs", :command => EditView::ToggleSoftTabsCommand,
                                 :type => :check, 
-                                :checked => lambda { tab and tab.edit_view.soft_tabs? }
+                                :checked => lambda { tab and tab.respond_to?(:edit_view) and tab.edit_view.soft_tabs? }
                                 
               sub_menu "Tab Width" do
                 TabSettings::TAB_WIDTHS.each do |width|
                   command_klass = Class.new(SetTabWidthCommand)
                   command_klass.width = width.to_i
-                  already_checker = lambda { tab and tab.edit_view.tab_width.to_s == width.to_s }
+                  already_checker = lambda { tab and tab.respond_to?(:edit_view) and tab.edit_view.tab_width.to_s == width.to_s }
                   item width, :command => command_klass, :type => :check, :checked => already_checker
                 end
               end
@@ -118,13 +118,13 @@ module Redcar
             sub_menu "Margin" do
               item "Word Wrap", :command => EditView::ToggleWordWrapCommand,
                                 :type => :check, 
-                                :checked => lambda { tab and tab.edit_view.word_wrap? }
+                                :checked => lambda { tab and tab.respond_to?(:edit_view) and tab.edit_view.word_wrap? }
               
               item "Show Margin", :command => EditView::ToggleShowMarginCommand,
                                   :type => :check, 
-                                  :checked => lambda { tab and tab.edit_view.show_margin? }
+                                  :checked => lambda { tab and tab.respond_to?(:edit_view) and tab.edit_view.show_margin? }
   
-              item lambda { tab ? "Margin Column: #{tab.edit_view.margin_column}" : "Margin Column" }, SetMarginColumnCommand
+              item lambda { tab && tab.respond_to?(:edit_view) ? "Margin Column: #{tab.edit_view.margin_column}" : "Margin Column" }, SetMarginColumnCommand
             end
 
             separator

--- a/plugins/help/plugin.rb
+++ b/plugins/help/plugin.rb
@@ -4,6 +4,4 @@ Plugin.define do
   version "1.0"
   file    "lib", "help"
   object  "Redcar::Help"
-  dependencies "web_bookmarks", ">0",
-               "open_default_app", ">0.1"
 end

--- a/plugins/plugin_manager_ui/lib/plugin_manager_ui.rb
+++ b/plugins/plugin_manager_ui/lib/plugin_manager_ui.rb
@@ -73,15 +73,58 @@ module Redcar
         end
         
         def reload_plugin(name)
-          plugin = Redcar.plugin_manager.loaded_plugins.detect {|pl| pl.name == name }
-          plugin ||= Redcar.plugin_manager.unloaded_plugins.detect {|pl| pl.name == name }
+          plugin = Redcar.plugin_manager.latest_version_by_name name
           plugin.load
+          Redcar.plugin_manager.loaded_plugins << plugin unless
+            Redcar.plugin_manager.loaded_plugins.include? plugin
           Redcar.app.refresh_menu!
           PluginManagerUi.last_reloaded = plugin
           nil
         end
+
+        def enable_plugin(name)
+          disabled_plugins = Redcar.plugin_manager.disabled_plugins.collect &:name
+
+          # Make sure none of it's dependencies are disabled.
+          plugin = Redcar.plugin_manager.latest_version_by_name name
+          deps = plugin.dependencies.collect(&:required_name) & disabled_plugins
+
+          if deps.empty?
+            reload_plugin name
+            Redcar.plugin_manager.disabled_plugins = disabled_plugins - [name]
+            save_disabled_plugins
+            {:message => "#{name} plugin enabled", :label => 'Disable'}
+          else
+            {:message => "#{name} requires #{deps * ', '} to be enabled first"}
+          end
+        end
+
+        def disable_plugin(name)
+
+          # Make sure nobody is active that depends on it
+          plugin = Redcar.plugin_manager.latest_version_by_name name
+          deps = Redcar.plugin_manager.derivative_plugins_for(plugin) &
+            Redcar.plugin_manager.loaded_plugins
+
+          if deps.empty?
+            Redcar.plugin_manager.loaded_plugins.reject! {|p| p.name == name}
+            Redcar.plugin_manager.disabled_plugins =
+              Redcar.plugin_manager.disabled_plugins.collect(&:name) + [name]
+            save_disabled_plugins
+            {:message => "Plugin #{name} will be disabled on restart", :label => 'Enable'}
+          else
+            {:message => "Cannot disable #{name} because needed by #{deps.collect(&:name) * ', '}"}
+          end
+        end
         
         private
+
+        # Will persist the new list of disabled plugins to disk
+        def save_disabled_plugins
+          path = File.join Redcar.user_dir, 'storage/disabled_plugins.yaml'
+          disabled = Redcar.plugin_manager.disabled_plugins.collect &:name
+          File.open(path, 'w') {|io| YAML.dump disabled, io}
+        end
         
         def plugin_table(plugins)
           str = "<table>\n"
@@ -89,9 +132,15 @@ module Redcar
           plugins = plugins.sort_by {|pl| pl.name.downcase }
           plugins.each do |plugin|
             name = plugin.is_a?(PluginManager::PluginDefinition) ? plugin.name : plugin
+            derivatives = Redcar.plugin_manager.derivative_plugins_for(plugin).collect(&:name) * ', '
             str << "<tr class=\"#{highlight ? "grey" : ""}\">"
-            str << "<td class=\"plugin\"><span class=\"plugin-name\">" + name + "</span></td>"
-            if plugin.load_time
+            str << "<td class=\"plugin\">"
+            str << "  <div class=\"plugin-name\">#{name}</div>"
+            unless derivatives.empty?
+              str << "<div class=\"derivatives\">Needed by: #{derivatives}</div>"
+            end
+            str << "</td>"
+            if Redcar.plugin_manager.loaded_plugins.include? plugin
               if plugin.load_time > 1
                 clss = "red"
               elsif plugin.load_time > 0.1
@@ -99,11 +148,12 @@ module Redcar
               else
                 clss = ""
               end
+              str << "<td class=#{ clss }>#{ plugin.load_time.to_s }</td>"
+              str << "<td class=\"links\"><a href=\"#\">Reload</a></td>"
+              str << "<td class=\"links\"><a href=\"#\">Disable</a></td>"
             else
-              clss = ""
+              str << "<td class=\"links\"><a href=\"#\">Enable</a></td>"
             end
-            str << "<td class=#{ clss }>#{ plugin.load_time.to_s }</td>"
-            str << "<td class=\"links\"><a href=\"#\">Reload</a>" + "</td>"
             str << "</tr>"
             highlight = !highlight
           end

--- a/plugins/plugin_manager_ui/views/index.html.erb
+++ b/plugins/plugin_manager_ui/views/index.html.erb
@@ -6,6 +6,7 @@ td.red {
 td.yellow {
   background-color: #FFFFCC;
 }
+.derivatives {font-size: 80%; color: gray}
 </style>
 
 
@@ -26,6 +27,9 @@ td.yellow {
 <h4>Loaded Plugins</h4>
 <%= plugin_table(Redcar.plugin_manager.loaded_plugins) %>
 
+<h4>Disabled Plugins</h4>
+<%= plugin_table(Redcar.plugin_manager.disabled_plugins) %>
+
 <h4>Unloaded Plugins</h4>
 <%= plugin_table(Redcar.plugin_manager.unloaded_plugins) %>
 
@@ -34,13 +38,21 @@ td.yellow {
 
 <h4>Plugins with Errors</h4>
 <%= plugin_table(Redcar.plugin_manager.plugins_with_errors) %>
+
 <h4>Browser Details</h4>
 <script language="javascript">
   $("a").click(function(e) {
     e.preventDefault();
-    var pluginName = $(this).parent().parent().find(".plugin-name").text();
+    var action = this.innerText.toLowerCase() + 'Plugin';
+    var record = $(this).parent().parent();
+    var pluginName = record.find(".plugin-name").text();
     try {
-      Controller.reloadPlugin(pluginName);
+      response = Controller[action](pluginName);
+
+      if( response ) {
+        if( response['message'] ) alert(response['message']);
+        if( response['label'] ) this.innerText = response['label'];
+      }
     } catch(e) {
       alert(e.message);
     }

--- a/plugins/redcar/plugin.rb
+++ b/plugins/redcar/plugin.rb
@@ -10,8 +10,6 @@ Plugin.define do
                "Auto Completer",    ">0",
                "auto_indenter",     ">0",
                "document_search",   ">0",
-               "runnables",         ">0",
-               "sessions",          ">0",
                "HTML View",         ">=0.3.2",
                "Plugin Manager UI", ">=0.3.2"
 end

--- a/plugins/redcar/redcar.rb
+++ b/plugins/redcar/redcar.rb
@@ -913,8 +913,6 @@ Redcar.environment: #{Redcar.environment}
         end
         sub_menu "Debug", :priority => 20 do
           group(:priority => 10) do
-            item "Task Manager", TaskManager::OpenCommand
-            separator
             item "Print Scope Tree", PrintScopeTreeCommand
             item "Print Scope at Cursor", PrintScopeCommand
           end

--- a/plugins/task_manager/lib/task_manager.rb
+++ b/plugins/task_manager/lib/task_manager.rb
@@ -4,6 +4,18 @@ require 'cgi'
 
 module Redcar
   class TaskManager
+
+    def self.menus
+      Menu::Builder.build do
+        sub_menu "Debug", :priority => 20 do
+          group(:priority => 5) do
+            item "Task Manager", TaskManager::OpenCommand
+            separator
+          end
+        end
+      end
+    end
+
     class OpenCommand < Redcar::Command
       
       def execute


### PR DESCRIPTION
Here is the rest of the support to allow disabling plugins. This is actually two patches. The first is a bug fix that prevents the "Reload" from working if the Plugin Manager is on screen. The second is the actual meat. I made the following changes to the Plugin UI.
- I added a link that will say "Enable" or "Disable" (depending on current state). When clicked it carries out the action and gives the user some feedback. Disabling only takes affect on restart but enable will have the plugin working right away (it basically does a reload after moving it to the right list and persisting changes, hence my bug fix).
- I added a list of all disabled plugins (as of boot time).
- To help the user know what plugins are dependent on others I put that in the UI. A plugin will list all other plugins that are using it as a dependency so you know what else you need to disable if you want to disable a plugin.

I am storing the list of disabled plugins under ~/.redcar/storage/disabled_plugins.yaml. It is just a simply YAML list.

I am NOT currently making sure the user doesn't shoot themselves in the foot. If they really want they could theoretically disable all plugins. We may want to mark certain plugins are not able to be disabled (core, application). But if a user does do this (for some unknown reason) all they need to do is delete the disabled_plugins.yaml file and they are back up and running.
