### PR TITLE
Typo error fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Ruby text editor.
 
- * written in Ruby from the ground up
+ * is written in Ruby from the ground up
  * runs on JRuby (a fast, compatible Ruby implementation)
  * is cross-platform (Linux, Mac OS X, Windows)
  * highly extensible


### PR DESCRIPTION
In the Description section, there is a typo error. 
The line is written as:
"A Ruby text editor.
- written in Ruby from the ground up."

As 'A Ruby text editor' is written in the heading and all of its features are written in bullet points, so all the bullet points must follow the heading to form a complete sentence. But in the bullet point provided above, 'is' is missing.

The correct line could be written as, 
"A Ruby text editor.
- is written in Ruby from the ground up."

Thank you.